### PR TITLE
fix: restrict mobile menu visibility to authenticated users

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -192,12 +192,15 @@ const Navbar = ({ onSearch, onUploadClick, onMyUploadsClick, onLogout, user, the
             )}
 
 
-            <button
-              className="sm:hidden p-1.5 rounded-lg text-slate-400 hover:text-white hover:bg-white/10 transition-colors"
-              onClick={() => setMenuOpen(!menuOpen)}
-            >
+           {user && (
+              <button
+                className="sm:hidden p-1.5 rounded-lg text-slate-400 hover:text-white hover:bg-white/10 transition-colors"
+                onClick={() => setMenuOpen(!menuOpen)}
+              >
+      
               {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
             </button>
+           })
           </div>
         </div>
 

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -200,7 +200,7 @@ const Navbar = ({ onSearch, onUploadClick, onMyUploadsClick, onLogout, user, the
       
               {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
             </button>
-           })
+           )}
           </div>
         </div>
 


### PR DESCRIPTION
## Description
This PR addresses the issue where the mobile hamburger menu was visible to guests, leading to an empty menu display. 

## Changes
- Wrapped the mobile menu toggle button in a conditional check for the `user` object.
- Ensures only authenticated (admin) users can access the navigation menu on small screens.

Fixes #5