### PR TITLE
feat: add unified GitHub Sponsors support to Navbar and Sidebar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, memo } from 'react';
-import { Search, Upload, X, LogOut, ChevronDown, ImagePlus, User } from 'lucide-react';
+import { Search, Upload, X, LogOut, ChevronDown, ImagePlus, User, Heart } from 'lucide-react';
+
 
 // ─────────────────────────────────────────────────────────────────
 // Navbar — always-visible search, Upload / Login / Sign Up actions
@@ -24,6 +25,26 @@ const Navbar = memo(({
 
           {/* ── Right Actions ── */}
           <div className="flex items-center gap-2 flex-shrink-0">
+
+            {/* GitHub Sponsors Button */}
+            <a
+              href="https://github.com/sponsors/seffhunnn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="
+                group fv-sponsor-btn
+                flex items-center gap-1.5
+                px-3.5 py-2 rounded-full
+                bg-[var(--surface-2)] border border-[var(--border)]
+                text-[var(--text-secondary)] hover:text-[var(--text-primary)]
+                text-[13px] font-semibold
+              "
+              aria-label="Sponsor seffhunnn on GitHub"
+            >
+              <Heart className="w-3.5 h-3.5 text-pink-500 fill-none group-hover:fill-pink-500 transition-all duration-200" />
+              <span>Sponsor</span>
+            </a>
+
 
             {/* Upload button (only show when authenticated) */}
             {user && (

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -317,8 +317,30 @@ const Sidebar = memo(({
             </button>
           </div>
 
-          <div className="mt-4 pt-3 border-t border-[var(--border)]">
-            <div className="flex items-center justify-center gap-1">
+          <div className="mt-4 pt-3 border-t border-[var(--border)] flex flex-col items-center gap-2">
+            <div className="flex flex-col items-center w-full px-2">
+              <span className="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-semibold mb-1.5 select-none">
+                Support FragVerse
+              </span>
+              <a
+                href="https://github.com/sponsors/seffhunnn"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="
+                  group fv-sponsor-btn
+                  w-full flex items-center justify-center gap-1.5
+                  px-3.5 py-2 rounded-full
+                  bg-[var(--surface-2)] border border-[var(--border)]
+                  text-[var(--text-secondary)] hover:text-[var(--text-primary)]
+                  text-[13px] font-semibold
+                "
+                aria-label="Sponsor seffhunnn on GitHub"
+              >
+                <Heart className="w-3.5 h-3.5 text-pink-500 fill-none group-hover:fill-pink-500 transition-all duration-200" />
+                <span>Sponsor</span>
+              </a>
+            </div>
+            <div className="flex items-center justify-center gap-1 mt-1">
               {SOCIAL_ITEMS.map(item => (
                 <SidebarSocialIcon key={item.label} item={item} />
               ))}

--- a/src/index.css
+++ b/src/index.css
@@ -8,61 +8,64 @@
 /* ── CSS Design Tokens ────────────────────────────────────────── */
 :root {
   /* Surfaces */
-  --bg:           #FAFAFA;
-  --surface:      #FFFFFF;
-  --sidebar-bg:   linear-gradient(180deg, #FFFFFF 0%, #F9F8FC 100%);
-  --surface-2:    #F4F4F6;
-  --border:       #E8E8EC;
+  --bg: #FAFAFA;
+  --surface: #FFFFFF;
+  --sidebar-bg: linear-gradient(180deg, #FFFFFF 0%, #F9F8FC 100%);
+  --surface-2: #F4F4F6;
+  --border: #E8E8EC;
   --border-hover: #D4D4DA;
 
   /* Text */
-  --text-primary:   #111111;
+  --text-primary: #111111;
   --text-secondary: #666666;
-  --text-muted:     #999999;
+  --text-muted: #999999;
 
   /* Accent */
-  --accent:       #7C3AED;
-  --accent-soft:  #8B5CF6;
+  --accent: #7C3AED;
+  --accent-soft: #8B5CF6;
   --accent-light: #A78BFA;
-  --accent-tint:  #EDE9FE;
+  --accent-tint: #EDE9FE;
 
   /* Shadows */
-  --shadow-card:       0 2px 12px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04);
-  --shadow-card-hover: 0 8px 30px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.06);
-  --shadow-panel:      0 4px 24px rgba(0,0,0,0.08);
+  --shadow-card: 0 2px 12px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.04);
+  --shadow-card-hover: 0 8px 30px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
+  --shadow-panel: 0 4px 24px rgba(0, 0, 0, 0.08);
 
   /* Radius */
-  --radius-card:  18px;
-  --radius-pill:  999px;
+  --radius-card: 18px;
+  --radius-pill: 999px;
   --radius-input: 12px;
   --radius-modal: 24px;
 }
 
 .dark {
-  --bg:           #0F0F11;
-  --surface:      #1A1A1F;
-  --sidebar-bg:   linear-gradient(180deg, #1A1A1F 0%, #131318 100%);
-  --surface-2:    #242429;
-  --border:       rgba(255,255,255,0.07);
-  --border-hover: rgba(255,255,255,0.12);
+  --bg: #0F0F11;
+  --surface: #1A1A1F;
+  --sidebar-bg: linear-gradient(180deg, #1A1A1F 0%, #131318 100%);
+  --surface-2: #242429;
+  --border: rgba(255, 255, 255, 0.07);
+  --border-hover: rgba(255, 255, 255, 0.12);
 
-  --text-primary:   #F0F0F0;
+  --text-primary: #F0F0F0;
   --text-secondary: #888888;
-  --text-muted:     #555555;
+  --text-muted: #555555;
 
-  --accent:       #8B5CF6;
-  --accent-soft:  #A78BFA;
+  --accent: #8B5CF6;
+  --accent-soft: #A78BFA;
   --accent-light: #C4B5FD;
-  --accent-tint:  rgba(139,92,246,0.15);
+  --accent-tint: rgba(139, 92, 246, 0.15);
 
-  --shadow-card:       none;
-  --shadow-card-hover: 0 8px 30px rgba(0,0,0,0.45);
-  --shadow-panel:      0 4px 24px rgba(0,0,0,0.35);
+  --shadow-card: none;
+  --shadow-card-hover: 0 8px 30px rgba(0, 0, 0, 0.45);
+  --shadow-panel: 0 4px 24px rgba(0, 0, 0, 0.35);
 }
 
 /* ── Base Reset ───────────────────────────────────────────────── */
 @layer base {
-  *, *::before, *::after {
+
+  *,
+  *::before,
+  *::after {
     box-sizing: border-box;
     margin: 0;
     padding: 0;
@@ -98,13 +101,22 @@
   }
 
   /* ── Scrollbar ── */
-  ::-webkit-scrollbar        { width: 5px; }
-  ::-webkit-scrollbar-track  { background: transparent; }
-  ::-webkit-scrollbar-thumb  {
+  ::-webkit-scrollbar {
+    width: 5px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
     background: #D4D4DA;
     border-radius: 999px;
   }
-  .dark ::-webkit-scrollbar-thumb { background: #3A3A43; }
+
+  .dark ::-webkit-scrollbar-thumb {
+    background: #3A3A43;
+  }
 }
 
 /* ── Component Utilities ──────────────────────────────────────── */
@@ -116,12 +128,14 @@
     padding-left: 1rem;
     padding-right: 1rem;
   }
+
   @media (min-width: 640px) {
     .fv-page-container {
       padding-left: 1.5rem;
       padding-right: 1.5rem;
     }
   }
+
   @media (min-width: 1024px) {
     .fv-page-container {
       padding-left: 2.5rem;
@@ -150,6 +164,7 @@
   .fv-card-hover {
     transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.2s ease;
   }
+
   .fv-card-hover:hover {
     transform: translateY(-3px) scale(1.01);
     box-shadow: var(--shadow-card-hover);
@@ -159,8 +174,8 @@
   /* Search / input ring on focus */
   .fv-input-focus:focus {
     outline: none;
-    box-shadow: 0 0 0 3px rgba(124,58,237,0.12);
-    border-color: rgba(124,58,237,0.4);
+    box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.12);
+    border-color: rgba(124, 58, 237, 0.4);
   }
 
   /* Pill chip — category button base */
@@ -180,20 +195,23 @@
     transition: all 0.18s ease;
     user-select: none;
   }
+
   .fv-chip:hover {
     border-color: var(--border-hover);
     background: var(--surface-2);
     color: var(--text-primary);
   }
+
   .fv-chip.active {
     background: var(--accent-tint);
-    border-color: rgba(124,58,237,0.25);
+    border-color: rgba(124, 58, 237, 0.25);
     color: var(--accent);
     font-weight: 600;
   }
+
   .dark .fv-chip.active {
     background: var(--accent-tint);
-    border-color: rgba(139,92,246,0.3);
+    border-color: rgba(139, 92, 246, 0.3);
     color: var(--accent-light);
   }
 
@@ -214,12 +232,14 @@
     transition: all 0.22s ease;
     user-select: none;
   }
+
   .fv-category-chip:hover {
     border-color: var(--border-hover);
     background: var(--surface-2);
     color: var(--text-primary);
     transform: translateY(-1px);
   }
+
   .fv-category-chip.active {
     background: var(--accent-tint);
     border-color: rgba(124, 58, 237, 0.35);
@@ -228,6 +248,7 @@
     box-shadow: 0 0 12px rgba(124, 58, 237, 0.08);
     transform: scale(0.98);
   }
+
   .dark .fv-category-chip.active {
     background: var(--accent-tint);
     border-color: rgba(139, 92, 246, 0.4);
@@ -240,29 +261,29 @@
     overflow: hidden;
     background-color: var(--surface-2);
   }
+
   .fv-skeleton::after {
     content: "";
     position: absolute;
     inset: 0;
     transform: translate3d(-100%, 0, 0);
-    background: linear-gradient(
-      90deg,
-      transparent 0%,
-      var(--border) 50%,
-      transparent 100%
-    );
+    background: linear-gradient(90deg,
+        transparent 0%,
+        var(--border) 50%,
+        transparent 100%);
     animation: shimmer-gpu 1.8s infinite;
     will-change: transform;
   }
 
   /* Navbar glass */
   .fv-navbar {
-    background: rgba(250,250,250,0.85);
+    background: rgba(250, 250, 250, 0.85);
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
   }
+
   .dark .fv-navbar {
-    background: rgba(15,15,17,0.85);
+    background: rgba(15, 15, 17, 0.85);
   }
 
   /* Button — primary */
@@ -280,8 +301,16 @@
     cursor: pointer;
     transition: opacity 0.18s ease, transform 0.18s ease;
   }
-  .fv-btn-primary:hover  { opacity: 0.88; transform: translateY(-1px); }
-  .fv-btn-primary:active { opacity: 1;    transform: translateY(0); }
+
+  .fv-btn-primary:hover {
+    opacity: 0.88;
+    transform: translateY(-1px);
+  }
+
+  .fv-btn-primary:active {
+    opacity: 1;
+    transform: translateY(0);
+  }
 
   /* Button — ghost */
   .fv-btn-ghost {
@@ -298,6 +327,7 @@
     cursor: pointer;
     transition: all 0.18s ease;
   }
+
   .fv-btn-ghost:hover {
     border-color: var(--border-hover);
     color: var(--text-primary);
@@ -307,13 +337,17 @@
 
 /* ── Utility Overrides ────────────────────────────────────────── */
 @layer utilities {
+
   /* Accent text — subtle, no neon */
   .text-accent {
     color: var(--accent);
   }
 
   /* Hide scrollbar utility */
-  .hide-scrollbar::-webkit-scrollbar { display: none; }
+  .hide-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
   .hide-scrollbar {
     -ms-overflow-style: none;
     scrollbar-width: none;
@@ -338,22 +372,36 @@
     column-count: 2;
     column-gap: 0.5rem;
   }
+
   @media (min-width: 640px) {
-    .fv-masonry { column-count: 3; column-gap: 0.625rem; }
+    .fv-masonry {
+      column-count: 3;
+      column-gap: 0.625rem;
+    }
   }
+
   @media (min-width: 1024px) {
-    .fv-masonry { column-count: 4; column-gap: 0.75rem; }
+    .fv-masonry {
+      column-count: 4;
+      column-gap: 0.75rem;
+    }
   }
+
   @media (min-width: 1280px) {
-    .fv-masonry { column-count: 5; column-gap: 0.75rem; }
+    .fv-masonry {
+      column-count: 5;
+      column-gap: 0.75rem;
+    }
   }
+
   .fv-masonry-item {
     break-inside: avoid;
     -webkit-column-break-inside: avoid;
     page-break-inside: avoid;
     margin-bottom: 0.5rem;
     display: inline-block;
-    vertical-align: top;  /* critical: prevents baseline gaps on inline-block */
+    vertical-align: top;
+    /* critical: prevents baseline gaps on inline-block */
     width: 100%;
   }
 
@@ -370,6 +418,7 @@
     border-radius: 16px;
     border: 1px solid transparent;
   }
+
   .fv-search-wrap-focus {
     border-color: rgba(124, 58, 237, 0.35);
     box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.1);
@@ -385,14 +434,17 @@
     font-weight: 500;
     transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
   }
+
   .fv-search-input::placeholder {
     color: var(--text-muted);
     font-weight: 400;
   }
+
   .fv-search-input:hover {
     border-color: var(--border-hover);
     background: color-mix(in srgb, var(--surface) 80%, transparent);
   }
+
   .fv-search-input:focus {
     outline: none;
     border-color: rgba(124, 58, 237, 0.45);
@@ -403,6 +455,7 @@
   .fv-sort-wrap {
     min-width: 148px;
   }
+
   .fv-sort-select {
     width: 100%;
     appearance: none;
@@ -417,10 +470,12 @@
     transition: all 0.2s ease;
     backdrop-filter: blur(12px);
   }
+
   .fv-sort-select:hover {
     border-color: var(--border-hover);
     background: var(--surface);
   }
+
   .fv-sort-select:focus {
     outline: none;
     border-color: rgba(124, 58, 237, 0.45);
@@ -437,29 +492,27 @@
     font-weight: 600;
     color: var(--text-secondary);
     border: 1px solid var(--border);
-    background: linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--mood-tint, #7c3aed) 10%, transparent),
-      var(--surface)
-    );
+    background: linear-gradient(135deg,
+        color-mix(in srgb, var(--mood-tint, #7c3aed) 10%, transparent),
+        var(--surface));
     cursor: pointer;
     transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease, background 0.22s ease;
     box-shadow: var(--shadow-card);
   }
+
   .fv-mood-chip:hover {
     transform: translateY(-2px);
     border-color: var(--border-hover);
     box-shadow: var(--shadow-card-hover);
     color: var(--text-primary);
   }
+
   .fv-mood-chip-active {
     color: var(--accent);
     border-color: color-mix(in srgb, var(--mood-tint, #7c3aed) 40%, transparent);
-    background: linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--mood-tint, #7c3aed) 18%, transparent),
-      var(--accent-tint)
-    );
+    background: linear-gradient(135deg,
+        color-mix(in srgb, var(--mood-tint, #7c3aed) 18%, transparent),
+        var(--accent-tint));
     box-shadow: 0 4px 18px color-mix(in srgb, var(--mood-tint, #7c3aed) 15%, transparent);
     transform: translateY(-1px);
   }
@@ -467,22 +520,34 @@
   /* Explore hero — stable overlay (never flickers with slides) */
   .fv-hero-overlay {
     background:
-      linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.22) 48%, rgba(0,0,0,0.12) 100%),
-      linear-gradient(to right, rgba(0,0,0,0.38) 0%, transparent 52%);
+      linear-gradient(to top, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0.22) 48%, rgba(0, 0, 0, 0.12) 100%),
+      linear-gradient(to right, rgba(0, 0, 0, 0.38) 0%, transparent 52%);
   }
 
   .fv-todays-picks {
     column-count: 2;
     column-gap: 0.5rem;
   }
+
   @media (min-width: 640px) {
-    .fv-todays-picks { column-count: 3; column-gap: 0.625rem; }
+    .fv-todays-picks {
+      column-count: 3;
+      column-gap: 0.625rem;
+    }
   }
+
   @media (min-width: 768px) {
-    .fv-todays-picks { column-count: 3; column-gap: 0.625rem; }
+    .fv-todays-picks {
+      column-count: 3;
+      column-gap: 0.625rem;
+    }
   }
+
   @media (min-width: 1280px) {
-    .fv-todays-picks { column-count: 4; column-gap: 0.75rem; }
+    .fv-todays-picks {
+      column-count: 4;
+      column-gap: 0.75rem;
+    }
   }
 
   /* Explore hero slideshow — slow Ken Burns (GPU-friendly) */
@@ -491,6 +556,7 @@
     transform-origin: center center;
     will-change: transform;
   }
+
   .fv-hero-ken-burns-active {
     animation: fvHeroKenBurns 7s ease-out forwards;
   }
@@ -501,6 +567,7 @@
   0% {
     transform: translate3d(-100%, 0, 0);
   }
+
   100% {
     transform: translate3d(100%, 0, 0);
   }
@@ -508,44 +575,87 @@
 
 /* Card soft-reveal: pure opacity, no movement, GPU-safe */
 @keyframes fvCardReveal {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(16px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes scaleIn {
-  from { opacity: 0; transform: scale(0.96); }
-  to   { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @keyframes slideUp {
-  from { opacity: 0; transform: translateY(10px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes fvHeroKenBurns {
   from {
     transform: scale(1.05) translate3d(0, 0, 0);
   }
+
   to {
     transform: scale(1.11) translate3d(-0.35%, -0.2%, 0);
   }
 }
 
 /* Helper classes */
-.animate-fade-in   { animation: fadeIn  0.4s ease-out both; }
-.animate-fade-up   { animation: fadeUp  0.5s cubic-bezier(0.16,1,0.3,1) both; }
-.animate-scale-in  { animation: scaleIn 0.2s cubic-bezier(0.16,1,0.3,1) both; }
-.animate-slide-up  { animation: slideUp 0.35s cubic-bezier(0.16,1,0.3,1) both; }
+.animate-fade-in {
+  animation: fadeIn 0.4s ease-out both;
+}
+
+.animate-fade-up {
+  animation: fadeUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.animate-scale-in {
+  animation: scaleIn 0.2s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.animate-slide-up {
+  animation: slideUp 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
 
 /* Wallpaper card reveal — soft opacity-only fade, GPU composited */
 .fv-card-reveal {
@@ -587,7 +697,9 @@
 }
 
 @keyframes fvSpinner {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Wallpaper card image transitions to prevent tailwind class conflicts */
@@ -598,43 +710,78 @@
 
 /* Global Search Command Palette Transitions */
 @keyframes fvSearchBackdropIn {
-  from { opacity: 0; backdrop-filter: blur(0px); -webkit-backdrop-filter: blur(0px); }
-  to   { opacity: 1; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
+  from {
+    opacity: 0;
+    backdrop-filter: blur(0px);
+    -webkit-backdrop-filter: blur(0px);
+  }
+
+  to {
+    opacity: 1;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+  }
 }
 
 @keyframes fvSearchBackdropOut {
-  from { opacity: 1; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); }
-  to   { opacity: 0; backdrop-filter: blur(0px); -webkit-backdrop-filter: blur(0px); }
+  from {
+    opacity: 1;
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+  }
+
+  to {
+    opacity: 0;
+    backdrop-filter: blur(0px);
+    -webkit-backdrop-filter: blur(0px);
+  }
 }
 
 @keyframes fvSearchPanelIn {
-  from { opacity: 0; transform: translate3d(-50%, -15px, 0) scale(0.97); }
-  to   { opacity: 1; transform: translate3d(-50%, 0, 0) scale(1); }
+  from {
+    opacity: 0;
+    transform: translate3d(-50%, -15px, 0) scale(0.97);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(-50%, 0, 0) scale(1);
+  }
 }
 
 @keyframes fvSearchPanelOut {
-  from { opacity: 1; transform: translate3d(-50%, 0, 0) scale(1); }
-  to   { opacity: 0; transform: translate3d(-50%, -15px, 0) scale(0.97); }
+  from {
+    opacity: 1;
+    transform: translate3d(-50%, 0, 0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translate3d(-50%, -15px, 0) scale(0.97);
+  }
 }
 
 .fv-search-overlay {
-  animation: fvSearchBackdropIn 0.22s cubic-bezier(0.16,1,0.3,1) both;
+  animation: fvSearchBackdropIn 0.22s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
+
 .fv-search-overlay.closing {
-  animation: fvSearchBackdropOut 0.2s cubic-bezier(0.16,1,0.3,1) both;
+  animation: fvSearchBackdropOut 0.2s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 .fv-search-panel {
-  animation: fvSearchPanelIn 0.25s cubic-bezier(0.16,1,0.3,1) both;
+  animation: fvSearchPanelIn 0.25s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
+
 .fv-search-panel.closing {
-  animation: fvSearchPanelOut 0.22s cubic-bezier(0.16,1,0.3,1) both;
+  animation: fvSearchPanelOut 0.22s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 /* Custom grid gap variable for exact math in compact layout */
 .fv-grid-compact-container {
   --grid-gap: 8px;
 }
+
 @media (min-width: 640px) {
   .fv-grid-compact-container {
     --grid-gap: 10px;
@@ -645,6 +792,7 @@
 .bg-radial-vignette {
   background: radial-gradient(circle at center, transparent 30%, rgba(0, 0, 0, 0.8) 100%);
 }
+
 .bg-radial-vignette-light {
   background: radial-gradient(circle at center, transparent 40%, rgba(0, 0, 0, 0.05) 100%);
 }
@@ -701,3 +849,45 @@
   transition: opacity 1.2s cubic-bezier(0.16, 1, 0.3, 1), transform 1.2s cubic-bezier(0.16, 1, 0.3, 1) !important;
 }
 
+/* ── GitHub Sponsor Button Style, Hover Glow & Shine Animation ── */
+.fv-sponsor-btn {
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease !important;
+}
+
+.fv-sponsor-btn::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.3) 50%,
+    transparent 100%
+  );
+  transform: skewX(-20deg);
+  pointer-events: none;
+}
+
+.fv-sponsor-btn:hover {
+  border-color: rgba(236, 72, 153, 0.5) !important;
+  box-shadow: 0 0 16px rgba(236, 72, 153, 0.45) !important;
+  color: var(--text-primary) !important;
+}
+
+.fv-sponsor-btn:hover::after {
+  animation: fv-sponsor-shine 0.8s ease-out forwards;
+}
+
+@keyframes fv-sponsor-shine {
+  0% {
+    left: -150%;
+  }
+  100% {
+    left: 150%;
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Sponsors button to the navigation bar for quick access.
  * Added new "Support FragVerse" sponsor call-to-action block in the sidebar beneath the theme toggle.

* **Style**
  * Enhanced sponsor button styling with animated hover effects.
  * Refined CSS design tokens and component styling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->